### PR TITLE
PowerOF Alarm: Fix failure to trigger alarm resulting in a missed ala…

### DIFF
--- a/src/com/android/deskclock/alarms/AlarmStateManager.java
+++ b/src/com/android/deskclock/alarms/AlarmStateManager.java
@@ -1016,7 +1016,7 @@ public final class AlarmStateManager extends BroadcastReceiver {
          Intent intent = new Intent(ACTION_SET_POWEROFF_ALARM);
          intent.addFlags(Intent.FLAG_RECEIVER_FOREGROUND);
          intent.setPackage(POWER_OFF_ALARM_PACKAGE);
-         intent.putExtra(TIME, instance.getAlarmTime().getTimeInMillis());
+         intent.putExtra(TIME, instance.getAlarmTime().getTimeInMillis() - 2 * 60 * 1000);
          context.sendBroadcast(intent);
     }
 


### PR DESCRIPTION
…rm notification

The original commit causes the phone booting right on scheduled time, which results in a missed alarm notification, i.e., no alarm is triggered. This commit makes sure the phone boots 2 minutes before the scheduled time, which lets the app trigger the timely alarm.